### PR TITLE
feat: adds conversion of softmax from onnx to tosa as well as utilities

### DIFF
--- a/src/Conversion/ONNXToTOSA/CMakeLists.txt
+++ b/src/Conversion/ONNXToTOSA/CMakeLists.txt
@@ -4,6 +4,7 @@ add_onnx_mlir_library(OMONNXToTOSA
   ConvertONNXToTOSA.cpp
 
   Math/Elementwise.cpp
+  Math/Softmax.cpp
 
   LINK_LIBS PUBLIC
   OMONNXOps

--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -24,6 +24,8 @@ void populateONNXToTOSAConversionPattern(ConversionTarget &target,
   // Math
   populateLoweringONNXElementwiseOpToTOSAPattern(
       target, patterns, typeConverter, ctx);
+  populateLoweringONNXSoftmaxOpToTOSAPattern(
+      target, patterns, typeConverter, ctx);
 }
 
 // Performs lowering to TOSA dialect

--- a/src/Conversion/ONNXToTOSA/Math/Softmax.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Softmax.cpp
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------------- Softmax.cpp - Softmax Op --------------------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file lowers ONNX softmax operator to TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+namespace {
+
+template <typename Softmax>
+Value convertSoftmax(PatternRewriter &rewriter, Operation *op,
+    RankedTensorType rsumType, const Value &op1ExpIn, int axis,
+    int32_t inputRank) = delete;
+
+// Before opset 13, softmax reduces axis and every dimension following.
+template <>
+Value convertSoftmax<ONNXSoftmaxV11Op>(PatternRewriter &rewriter, Operation *op,
+    RankedTensorType rsumType, const Value &op1ExpIn, int axis,
+    int32_t inputRank) {
+  // Create shared outputType with dynamic shape. Infer method when creating
+  // ops will insert a static shape if possible
+  Type outputType = RankedTensorType::get(
+      llvm::SmallVector<int64_t, 4>(inputRank, -1), rsumType.getElementType());
+  // Create first reduce with input from function operands
+  Value reducedSum = tosa::CreateOpAndInfer<mlir::tosa::ReduceSumOp>(rewriter,
+      op->getLoc(), outputType, op1ExpIn, rewriter.getI64IntegerAttr(axis));
+  // Loop over all following dimensions with last reduce as input
+  for (int i = axis + 1; i < inputRank; i++) {
+    reducedSum = tosa::CreateOpAndInfer<mlir::tosa::ReduceSumOp>(rewriter,
+        op->getLoc(), outputType, reducedSum, rewriter.getI64IntegerAttr(i));
+  }
+  return reducedSum;
+}
+
+// From opset 13, softmax uses axis as the reduce axis.
+template <>
+Value convertSoftmax<ONNXSoftmaxOp>(PatternRewriter &rewriter, Operation *op,
+    RankedTensorType rsumType, const Value &op1ExpIn, int axis,
+    int32_t inputRank) {
+  return tosa::CreateOpAndInfer<mlir::tosa::ReduceSumOp>(rewriter, op->getLoc(),
+      rsumType, op1ExpIn, rewriter.getI64IntegerAttr(axis));
+}
+
+template <typename SoftmaxOp>
+class ONNXSoftmaxLoweringToTOSA : public OpConversionPattern<SoftmaxOp> {
+public:
+  using OpConversionPattern<SoftmaxOp>::OpConversionPattern;
+  using OpAdaptor = typename SoftmaxOp::Adaptor;
+  LogicalResult matchAndRewrite(SoftmaxOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // softmax = exp(logits) / reduce_sum(exp(logits), -1)
+    auto outputType = op.getResult().getType().template dyn_cast<TensorType>();
+    auto inputType = adaptor.input().getType().template dyn_cast<TensorType>();
+    IntegerAttr axisAttr = adaptor.axisAttr();
+
+    // reduce_sum on last dimension
+    int32_t inputRank = inputType.getShape().size();
+
+    // Get ONNX softmax axis
+    int axis = axisAttr.getSInt();
+    // Tosa only supports positive values
+    if (axis < 0) {
+      axis += inputRank;
+    }
+    // The legalization below is based on convertSoftmaxOp in
+    // tensorflow tosa/transforms/legalize_common.cc, with the
+    // addition of handling for axis.
+
+    // Not a ranked tensor input/output
+    if (!outputType || !inputType) {
+      return rewriter.notifyMatchFailure(
+          op, "input and result not ranked tensors");
+    }
+
+    // Floating-point lowering is more direct:
+    //
+    // op1 = exp(logits)
+    // op2 = reduce_sum(op1, -1)
+    // op3 = reciprocal(op2)
+    // op4 = mul(op1, op3)
+    auto op1ExpIn = tosa::CreateOpAndInfer<mlir::tosa::ExpOp>(
+        rewriter, op->getLoc(), outputType, adaptor.input());
+    RankedTensorType rsumType = RankedTensorType::get(
+        llvm::SmallVector<int64_t, 4>(inputType.getShape().size(), -1),
+        outputType.getElementType());
+
+    Value op2ReducesumOp1 = convertSoftmax<SoftmaxOp>(
+        rewriter, op, rsumType, op1ExpIn.getResult(), axis, inputRank);
+
+    auto op3ReciprocalOp2 = tosa::CreateOpAndInfer<mlir::tosa::ReciprocalOp>(
+        rewriter, op->getLoc(), op2ReducesumOp1.getType(), op2ReducesumOp1);
+
+    tosa::CreateReplaceOpAndInfer<mlir::tosa::MulOp>(rewriter, op, outputType,
+        op1ExpIn.getResult(), op3ReciprocalOp2.getResult(), 0);
+
+    return success();
+  }
+};
+
+} // namespace
+
+void populateLoweringONNXSoftmaxOpToTOSAPattern(ConversionTarget &target,
+    RewritePatternSet &patterns, TypeConverter &typeConverter,
+    MLIRContext *ctx) {
+  patterns.insert<ONNXSoftmaxLoweringToTOSA<ONNXSoftmaxOp>,
+      ONNXSoftmaxLoweringToTOSA<ONNXSoftmaxV11Op>>(typeConverter, ctx);
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -63,4 +63,6 @@ using TOSAOp = typename TOSADialectOp<Op>::Op;
 // `Math` directory methods:
 void populateLoweringONNXElementwiseOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXSoftmaxOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//==== ONNXToTosaLegalizeUtils.hpp - ONNX dialects to TOSA lowering Utils-===//
+//
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file contains common utils shared by the functions performing the
+// lowering to the TOSA dialect. It is also used by TensorFlow and torch-mlir.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ONNXMLIR_CONVERSION_ONNXTOTOSA_TOSALEGALIZEUTILS_H
+#define ONNXMLIR_CONVERSION_ONNXTOTOSA_TOSALEGALIZEUTILS_H
+
+#include "mlir/Dialect/Quant/QuantTypes.h"        // from @llvm-project
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"         // from @llvm-project
+#include "mlir/Dialect/Tosa/Utils/ShapeUtils.h"   // from @llvm-project
+#include "mlir/IR/BuiltinAttributes.h"            // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"                 // from @llvm-project
+#include "mlir/IR/PatternMatch.h"                 // from @llvm-project
+#include "mlir/Interfaces/InferTypeOpInterface.h" // from @llvm-project
+#include "mlir/Support/LLVM.h"                    // from @llvm-project
+
+namespace onnx_mlir {
+namespace tosa {
+
+// Creates a TOSA operation and performs shape inference on the individual
+// op. This allows shape inference during the framework to TOSA lowering.
+template <typename TosaOp, typename... Args>
+TosaOp CreateOpAndInfer(mlir::PatternRewriter &rewriter, mlir::Location loc,
+    mlir::Type result_ty, Args &&...args) {
+  auto op = rewriter.create<TosaOp>(loc, result_ty, args...);
+
+  mlir::InferShapedTypeOpInterface shapeInterface =
+      llvm::dyn_cast<mlir::InferShapedTypeOpInterface>(op.getOperation());
+  if (!shapeInterface)
+    return op;
+
+  llvm::SmallVector<mlir::ShapedTypeComponents> returnedShapes;
+  if (shapeInterface
+          .inferReturnTypeComponents(op.getContext(), op.getLoc(),
+              op->getOperands(), op->getAttrDictionary(), op->getRegions(),
+              returnedShapes)
+          .failed())
+    return op;
+
+  // We need to use the element type of the existing result type to generate
+  // the new result shaped type. This is because rescale can include a cast to
+  // different bit-width types and does not have a TypeAttr to define the
+  // target type.
+  auto result = op->getResult(0);
+  auto predictedShape = returnedShapes[0];
+  auto currentKnowledge =
+      mlir::tosa::ValueKnowledge::getKnowledgeFromType(result_ty);
+
+  // Compute the knowledge based on the inferred type.
+  auto inferredKnowledge =
+      mlir::tosa::ValueKnowledge::getPessimisticValueState();
+  inferredKnowledge.dtype = result_ty.cast<mlir::ShapedType>().getElementType();
+  inferredKnowledge.hasRank = predictedShape.hasRank();
+  if (predictedShape.hasRank()) {
+    for (auto dim : predictedShape.getDims()) {
+      inferredKnowledge.sizes.push_back(dim);
+    }
+  }
+
+  // Compute the new type based on the joined version.
+  auto newKnowledge =
+      mlir::tosa::ValueKnowledge::join(currentKnowledge, inferredKnowledge);
+  auto new_ty = newKnowledge.getType();
+  result.setType(new_ty);
+  return op;
+}
+
+template <typename TosaOp, typename... Args>
+void CreateReplaceOpAndInfer(mlir::PatternRewriter &rewriter,
+    mlir::Operation *op, mlir::Type result_ty, Args &&...args) {
+  auto result =
+      CreateOpAndInfer<TosaOp>(rewriter, op->getLoc(), result_ty, args...);
+  rewriter.replaceOp(op, result->getResults());
+}
+
+} // namespace tosa
+} // namespace onnx_mlir
+
+#endif // ONNXMLIR_CONVERSION_ONNXTOTOSA_TOSALEGALIZEUTILS_H

--- a/test/mlir/conversion/onnx_to_tosa/Math/Softmax.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Softmax.mlir
@@ -1,0 +1,50 @@
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
+
+func.func @test_softmax_v13(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  %2 = "onnx.Softmax"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  func.return %2 : tensor<13x21x3xf32>
+// CHECK: test_softmax_v13(%[[VAL_0:.*]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[VAL_1:.*]] = "tosa.exp"(%[[VAL_0]]) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[VAL_2:.*]] = "tosa.reduce_sum"(%[[VAL_1]]) {axis = 2 : i64} : (tensor<13x21x3xf32>) -> tensor<13x21x1xf32>
+// CHECK: %[[VAL_3:.*]] = "tosa.reciprocal"(%[[VAL_2]]) : (tensor<13x21x1xf32>) -> tensor<13x21x1xf32>
+// CHECK: %[[VAL_4:.*]] = "tosa.mul"(%[[VAL_1]], %[[VAL_3]]) {shift = 0 : i32} : (tensor<13x21x3xf32>, tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
+}
+
+// -----
+
+func.func @test_softmax_v13_axis_one(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  %2 = "onnx.Softmax"(%arg0) {axis = 1 : si64} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  func.return %2 : tensor<13x21x3xf32>
+// CHECK: test_softmax_v13_axis_one(%[[VAL_0:.*]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[VAL_1:.*]] = "tosa.exp"(%[[VAL_0]]) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[VAL_2:.*]] = "tosa.reduce_sum"(%[[VAL_1]]) {axis = 1 : i64} : (tensor<13x21x3xf32>) -> tensor<13x1x3xf32>
+// CHECK: %[[VAL_3:.*]] = "tosa.reciprocal"(%[[VAL_2]]) : (tensor<13x1x3xf32>) -> tensor<13x1x3xf32>
+// CHECK: %[[VAL_4:.*]] = "tosa.mul"(%[[VAL_1]], %[[VAL_3]]) {shift = 0 : i32} : (tensor<13x21x3xf32>, tensor<13x1x3xf32>) -> tensor<13x21x3xf32>
+}
+
+// -----
+
+func.func @test_softmax_before_v13(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  %2 = "onnx.SoftmaxV11"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  func.return %2 : tensor<13x21x3xf32>
+// CHECK: test_softmax_before_v13(%[[VAL_0:.*]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[VAL_1:.*]] = "tosa.exp"(%[[VAL_0]]) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[VAL_2:.*]] = "tosa.reduce_sum"(%[[VAL_1]]) {axis = 1 : i64} : (tensor<13x21x3xf32>) -> tensor<13x1x3xf32>
+// CHECK: %[[VAL_3:.*]] = "tosa.reduce_sum"(%[[VAL_2]]) {axis = 2 : i64} : (tensor<13x1x3xf32>) -> tensor<13x1x1xf32>
+// CHECK: %[[VAL_4:.*]] = "tosa.reciprocal"(%[[VAL_3]]) : (tensor<13x1x1xf32>) -> tensor<13x1x1xf32>
+// CHECK: %[[VAL_5:.*]] = "tosa.mul"(%[[VAL_1]], %[[VAL_4]]) {shift = 0 : i32} : (tensor<13x21x3xf32>, tensor<13x1x1xf32>) -> tensor<13x21x3xf32>
+}
+
+// -----
+
+func.func @test_softmax_before_v13_axis_zero(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  %2 = "onnx.SoftmaxV11"(%arg0) {axis = 0 : si64}: (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  func.return %2 : tensor<13x21x3xf32>
+// CHECK: test_softmax_before_v13_axis_zero(%[[VAL_0:.*]]: tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[VAL_1:.*]] = "tosa.exp"(%[[VAL_0]]) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+// CHECK: %[[VAL_2:.*]] = "tosa.reduce_sum"(%[[VAL_1]]) {axis = 0 : i64} : (tensor<13x21x3xf32>) -> tensor<1x21x3xf32>
+// CHECK: %[[VAL_3:.*]] = "tosa.reduce_sum"(%[[VAL_2]]) {axis = 1 : i64} : (tensor<1x21x3xf32>) -> tensor<1x1x3xf32>
+// CHECK: %[[VAL_4:.*]] = "tosa.reduce_sum"(%[[VAL_3]]) {axis = 2 : i64} : (tensor<1x1x3xf32>) -> tensor<1x1x1xf32>
+// CHECK: %[[VAL_5:.*]] = "tosa.reciprocal"(%[[VAL_4]]) : (tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
+// CHECK: %[[VAL_6:.*]] = "tosa.mul"(%[[VAL_1]], %[[VAL_5]]) {shift = 0 : i32} : (tensor<13x21x3xf32>, tensor<1x1x1xf32>) -> tensor<13x21x3xf32>
+}


### PR DESCRIPTION
Softmax does not have a 1:1 conversion to TOSA. To lower it we have to decompose it. The shape inference builder that TensorFlow and Pytorch are using was also added.

Signed-off-by: Maximilian Bartel <maximilian.bartel@amd.com>